### PR TITLE
fix: permissons

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
   release:
     name: "Release"
     runs-on: "ubuntu-latest"
+    permissions: write-all
     steps:
       - uses: "marvinpinto/action-automatic-releases@latest"
         with:


### PR DESCRIPTION
Without this permission the error showed instead of release:
**Error: Resource not accessible by integration**
![image](https://user-images.githubusercontent.com/65445916/228022748-59ec06fc-f645-4108-8125-a75805521a05.png)
Also, I believe, you should enable in Repository Configurations -> Actions -> General -> [Read and write permission]
![image](https://user-images.githubusercontent.com/65445916/228022919-caecb29b-6a3f-42c6-8dbc-3d9fcfd8c23d.png)
